### PR TITLE
Latest rend2

### DIFF
--- a/codemp/rd-rend2/tr_init.cpp
+++ b/codemp/rd-rend2/tr_init.cpp
@@ -1226,6 +1226,14 @@ void GL_SetDefaultState( void )
 
 	// set default vertex color
 	qglVertexAttrib4f(ATTR_INDEX_COLOR, 1.0f, 1.0f, 1.0f, 1.0f);
+
+	// invalidate all vertex step rates
+	// this ensures that attributes that have a set divisor will have a 
+	// correct divisor set after GL_SetDefaultState is called
+	for (int i = 0; i < ATTR_INDEX_MAX; i++)
+	{
+		glState.currentVaoAttribs[i].stepRate = -1;
+	}
 }
 
 /*

--- a/shared/rd-rend2/tr_sky.cpp
+++ b/shared/rd-rend2/tr_sky.cpp
@@ -453,6 +453,8 @@ static void DrawSkySide( struct image_s *image, const int mins[2], const int max
 		UNIFORM_DIFFUSETEXOFFTURB, 0.0f, 0.0f, 0.0f, 0.0f);
 	uniformDataWriter.SetUniformVec4(
 		UNIFORM_ENABLETEXTURES, 0.0f, 0.0f, 0.0f, 0.0f);
+	uniformDataWriter.SetUniformInt(
+		UNIFORM_ALPHA_TEST_TYPE, ALPHA_TEST_NONE);
 
 	samplerBindingsWriter.AddStaticImage(image, TB_DIFFUSEMAP);
 

--- a/shared/rd-rend2/tr_world.cpp
+++ b/shared/rd-rend2/tr_world.cpp
@@ -725,7 +725,7 @@ static mnode_t *R_PointInLeaf( const vec3_t p ) {
 		}
 		plane = node->plane;
 		d = DotProduct (p,plane->normal) - plane->dist;
-		if (d > 0) {
+		if (d >= 0) {
 			node = node->children[0];
 		} else {
 			node = node->children[1];


### PR DESCRIPTION
Fixed UB regarding instanced vertex attributes
Made point in leaf testing return same result as vanilla (Modells on structural bsp planes were culled differently, notable on mp/ffa5 for an example)
Fixed UB regarding alpha testing sky draws