### PR TITLE
[rend2] Fix MD3 surface with zero shaders dividing by zero

### DIFF
--- a/shared/rd-rend2/tr_mesh.cpp
+++ b/shared/rd-rend2/tr_mesh.cpp
@@ -371,12 +371,9 @@ void R_AddMD3Surfaces( trRefEntity_t *ent, int entityNum ) {
 			else if (shader->defaultShader) {
 				ri.Printf( PRINT_DEVELOPER, "WARNING: shader %s in skin %s not found\n", shader->name, skin->name);
 			}
-		//} else if ( surface->numShaders <= 0 ) {
-			//shader = tr.defaultShader;
+		} else if ( surface->numShaderIndexes <= 0 ) {
+			shader = tr.defaultShader;
 		} else {
-			//md3Shader = (md3Shader_t *) ( (byte *)surface + surface->ofsShaders );
-			//md3Shader += ent->e.skinNum % surface->numShaders;
-			//shader = tr.shaders[ md3Shader->shaderIndex ];
 			shader = tr.shaders[ surface->shaderIndexes[ ent->e.skinNum % surface->numShaderIndexes ] ];
 		}
 


### PR DESCRIPTION
Same fix as https://github.com/ioquake/ioq3/commit/d824cfa5a2ced2cfbfbc89509b8415aefd30949b