### PR TITLE
[rend2] Merge entity surfaces again

### DIFF
--- a/shared/rd-rend2/tr_surface.cpp
+++ b/shared/rd-rend2/tr_surface.cpp
@@ -2058,6 +2058,18 @@ static void RB_SurfaceEntity( surfaceType_t *surfType ) {
 		RB_SurfaceAxis();
 		break;
 	}
+
+	// Tell the backend to merge the drawcalls except 
+	// for types that can't be merged
+	// TODO: Create RT_BEAM internal shader and make it compatible with pass system 
+	switch( backEnd.currentEntity->e.reType ) {
+	case RT_BEAM:
+	case RT_ENT_CHAIN:
+		break;
+	default:
+		tess.shader->entityMergable = qtrue;
+		break;
+	}
 }
 
 static void RB_SurfaceBad( surfaceType_t *surfType ) {


### PR DESCRIPTION
This time making sure it's not messing up. RT_BEAM code issues a drawcall, potentially using previously added entity surfaces in tess messing up the rendering pipeline. Issue was visable at the end of nar_starpad in JO.