### PR TITLE
[rend2] Fix entity surface merging code ... again

### DIFF
--- a/shared/rd-rend2/tr_backend.cpp
+++ b/shared/rd-rend2/tr_backend.cpp
@@ -1264,7 +1264,7 @@ static void RB_SubmitDrawSurfsForDepthFill(
 		// seperate entities merged into a single batch, like smoke and blood
 		// puff sprites
 		if ( shader != oldShader ||
-				(entityNum != oldEntityNum && !shader->entityMergable) )
+				(entityNum != oldEntityNum && !tess.entityMergable) )
 		{
 			if ( oldShader != nullptr )
 			{
@@ -1360,7 +1360,7 @@ static void RB_SubmitDrawSurfs(
 				dlighted != oldDlighted ||
 				postRender != oldPostRender ||
 				cubemapIndex != oldCubemapIndex ||
-				(entityNum != oldEntityNum && !shader->entityMergable)) )
+				(entityNum != oldEntityNum && !tess.entityMergable)) )
 		{
 			if ( oldShader != nullptr )
 			{

--- a/shared/rd-rend2/tr_local.h
+++ b/shared/rd-rend2/tr_local.h
@@ -3151,7 +3151,8 @@ struct shaderCommands_s
 	float		shaderTime;
 	int			fogNum;
 	int         cubemapIndex;
-#ifdef REND2_SP_MAYBE
+	bool		entityMergable;
+#ifdef REND2_SP_GORE
 	bool		scale;		// uses texCoords[input->firstIndex] for storage
 	bool		fade;		// uses svars.colors[input->firstIndex] for storage
 #endif

--- a/shared/rd-rend2/tr_shade.cpp
+++ b/shared/rd-rend2/tr_shade.cpp
@@ -157,6 +157,7 @@ void RB_BeginSurface( shader_t *shader, int fogNum, int cubemapIndex )
 	tess.useInternalVBO = qtrue;
 
 	tess.shaderTime = backEnd.refdef.floatTime - tess.shader->timeOffset;
+	tess.entityMergable = (bool)shader->entityMergable;
 	if (tess.shader->clampTime && tess.shaderTime >= tess.shader->clampTime) {
 		tess.shaderTime = tess.shader->clampTime;
 	}

--- a/shared/rd-rend2/tr_surface.cpp
+++ b/shared/rd-rend2/tr_surface.cpp
@@ -2067,7 +2067,7 @@ static void RB_SurfaceEntity( surfaceType_t *surfType ) {
 	case RT_ENT_CHAIN:
 		break;
 	default:
-		tess.shader->entityMergable = qtrue;
+		tess.entityMergable = true;
 		break;
 	}
 }


### PR DESCRIPTION
It could happen that tr.defaultShader is set to be mergable which is a bad idea because tr.defaultShader is forced for the depth prepass.