### PR TITLE
[rend2] Fix broken stage collapsing after a7dd927af part 2

### DIFF
--- a/shared/rd-rend2/tr_shader.cpp
+++ b/shared/rd-rend2/tr_shader.cpp
@@ -3485,6 +3485,7 @@ static qboolean CollapseStagesToGLSL(void)
 		// Move diffuse after the lightmap stages now.
 		if (stages[1].active &&
 			stages[1].bundle[0].isLightmap &&
+			(stages[1].stateBits & (GLS_DEPTHFUNC_BITS)) != GLS_DEPTHFUNC_EQUAL &&
 			stages[0].active &&
 			shader.numDeforms != 1)
 		{


### PR DESCRIPTION
Don't shuffle lightmap and diffuse stage if the lightmap stage is dependent on the depth write of the first stage.